### PR TITLE
UsersMapper.javaのテーブル操作アノテーションと関数の戻り値型の変更

### DIFF
--- a/src/main/java/com/example/procon34_CYBER_WARS_backend/repository/UsersMapper.java
+++ b/src/main/java/com/example/procon34_CYBER_WARS_backend/repository/UsersMapper.java
@@ -1,15 +1,14 @@
 package com.example.procon34_CYBER_WARS_backend.repository;
 
+import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Select;
 
 import com.example.procon34_CYBER_WARS_backend.dto.UsersRegisterRequest;
-import com.example.procon34_CYBER_WARS_backend.entity.Users;
 
 @Mapper
 public interface UsersMapper {
 
-    @Select("INSERT INTO users(name, password) VALUES(#{name}, #{password})")
-    Users register(UsersRegisterRequest usersRegisterRequest);
+    @Insert("INSERT INTO users(name, password) VALUES(#{name}, #{password})")
+    void register(UsersRegisterRequest usersRegisterRequest);
 
 }


### PR DESCRIPTION
## Issueへのリンク
<!-- resolve: #Issue番号 -->
resolve: #44 

## 概要
テーブル操作のSQL文がINSERTなのにも関わらず`@Select`アノテーションになっているため修正
関数の戻り値は必要ないためvoidに変更

## 作業内容
- importするorg.apache.ibatis.annotationsの変更
- com.example.procon34_CYBER_WARS_backend.entity.Usersのimport削除
- テーブル操作のアノテーションのSelectからInsertへの変更
- 関数の戻り値型のUsersからvoidへの変更

## 動作確認
<!-- 必要であれば実施して記載 -->
アノテーションを変更しても問題なく動いた。というかアノテーションミスってても動く方がおかしい。
関数の戻り値変えても別の場所では受け取っていないので問題なく動いた。

## レビュワーへの参考情報
<!-- 実装上の懸念点やレビューにおける注意点などがもしあれば記載 -->
なし

## チェックリスト
- [x] タイトルを設定している
- [x] Issue へのリンクを設定している
- [x] Assignees を設定している
- [x] Labels を設定している

<!-- Create pull requestを押す前にPreviewを確認すること -->
