### PR TITLE
UsersRegisterRequest.javaの無駄なコードの削除と変数の修飾子の変更

### DIFF
--- a/src/main/java/com/example/procon34_CYBER_WARS_backend/dto/UsersRegisterRequest.java
+++ b/src/main/java/com/example/procon34_CYBER_WARS_backend/dto/UsersRegisterRequest.java
@@ -1,36 +1,18 @@
 package com.example.procon34_CYBER_WARS_backend.dto;
 
-import java.io.Serializable;
-
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
-public class UsersRegisterRequest implements Serializable {
+public class UsersRegisterRequest {
 
     @NotBlank
     @Size(max = 20)
-    private String name;
+    public String name;
 
     @NotBlank
     @Size(max = 100)
-    private String password;
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
+    public String password;
 
 }


### PR DESCRIPTION
## Issueへのリンク
<!-- resolve: #Issue番号 -->
resolve: #47 

## 概要
Serializableのimplementsをしなくても動くので削除。
Lombokの`@Data`アノテーションがGetterとSetterは自動生成してくれるためコードからは削除。
他からアクセスできるように変数の修飾子を変更。

## 作業内容
- Serializableのimportとimplementsの削除
- GetterとSetterの削除
- 変数の修飾子をprivateからpublicに変更

## 動作確認
<!-- 必要であれば実施して記載 -->
なし

## レビュワーへの参考情報
<!-- 実装上の懸念点やレビューにおける注意点などがもしあれば記載 -->
なし

## チェックリスト
- [x] タイトルを設定している
- [x] Issue へのリンクを設定している
- [x] Assignees を設定している
- [x] Labels を設定している

<!-- Create pull requestを押す前にPreviewを確認すること -->
