### PR TITLE
PasswordEncoder.javaにパスワードチェックの関数を追加

### DIFF
--- a/src/main/java/com/example/procon34_CYBER_WARS_backend/config/Config.java
+++ b/src/main/java/com/example/procon34_CYBER_WARS_backend/config/Config.java
@@ -3,6 +3,7 @@ package com.example.procon34_CYBER_WARS_backend.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -12,6 +13,11 @@ public class Config {
     public SecurityFilterChain configureHttp(HttpSecurity http) throws Exception {
         http.csrf().disable();
         return http.build();
+    }
+
+    @Bean
+    BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
 }

--- a/src/main/java/com/example/procon34_CYBER_WARS_backend/util/PasswordEncoder.java
+++ b/src/main/java/com/example/procon34_CYBER_WARS_backend/util/PasswordEncoder.java
@@ -1,22 +1,21 @@
 package com.example.procon34_CYBER_WARS_backend.util;
 
-import java.math.BigInteger;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 
 @Component
 public class PasswordEncoder {
 
+    @Autowired
+    BCryptPasswordEncoder bCryptPasswordEncoder;
+
     public String encodePassword(String password) {
-        try {
-            MessageDigest messageDigest = MessageDigest.getInstance("SHA3-256");
-            byte[] result = messageDigest.digest(password.getBytes());
-            return String.format("%040x", new BigInteger(1, result));
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
+        return bCryptPasswordEncoder.encode(password);
+    }
+
+    public boolean checkPassword(String password, String hashedPassword) {
+        return bCryptPasswordEncoder.matches(password, hashedPassword);
     }
 
 }


### PR DESCRIPTION
## Issueへのリンク
<!-- resolve: #Issue番号 -->
resolve: #52 

## 概要
~~BCryptだと、同じ値でもハッシュ処理を行うたびに、生成されるハッシュ値が変わってしまうため、変わることのないMessageDigestへ変更~~
PasswordEncoder.javaにパスワードチェックの関数を追加
BCryptPasswordEncoderを`@Autowired`するためにConfig.javaに`@Bean`を追加

## 作業内容
- matchesを使ってcheckPassword関数を追加
- Config.javaにBCryptPasswordEncoderの`@Bean`を追加

## 動作確認
<!-- 必要であれば実施して記載 -->
ハッシュ化の確認と再度ハッシュ化を行ったときに同じ値になることを確認

## レビュワーへの参考情報
<!-- 実装上の懸念点やレビューにおける注意点などがもしあれば記載 -->
なし

## チェックリスト
- [x] タイトルを設定している
- [x] Issue へのリンクを設定している
- [x] Assignees を設定している
- [x] Labels を設定している

<!-- Create pull requestを押す前にPreviewを確認すること -->
