### PR TITLE
SQLインジェクションの対策

### DIFF
--- a/src/main/java/jp/ac/anan/procon/cyber_wars/application/utility/StringFormatter.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/application/utility/StringFormatter.java
@@ -1,0 +1,12 @@
+package jp.ac.anan.procon.cyber_wars.application.utility;
+
+import org.apache.commons.text.StringEscapeUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StringFormatter {
+  // 文字列フォーマット
+  public String format(final String unformattedString) {
+    return StringEscapeUtils.escapeEcmaScript(StringEscapeUtils.escapeHtml4(unformattedString));
+  }
+}

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/utility/HttpClientErrorHandlerResponse.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/utility/HttpClientErrorHandlerResponse.java
@@ -1,0 +1,5 @@
+package jp.ac.anan.procon.cyber_wars.domain.dto.utility;
+
+import org.springframework.http.ResponseEntity;
+
+public record HttpClientErrorHandlerResponse(boolean error, ResponseEntity<?> responseEntity) {}

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/utility/HttpClientErrorHandlerResponse.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/utility/HttpClientErrorHandlerResponse.java
@@ -1,5 +1,0 @@
-package jp.ac.anan.procon.cyber_wars.domain.dto.utility;
-
-import org.springframework.http.ResponseEntity;
-
-public record HttpClientErrorHandlerResponse(boolean error, ResponseEntity<?> responseEntity) {}


### PR DESCRIPTION
## Issueへのリンク
<!-- resolve: #Issue番号 -->
resolve: #48

## 概要
今のままではAPIにSQLインジェクションの脆弱性があるので修正する。
SQLに入れる値は#{id}←このように書けば勝手にエスケープしてくれるとネットには書いているが、実際に試してみると危険な記号がそのままデータベースに保存されてしまった。

## 作業内容
- SQLインジェクションの対策コードの追加

## 動作確認
<!-- 必要であれば実施して記載 -->
なし

## レビュワーへの参考情報
<!-- 実装上の懸念点やレビューにおける注意点などがもしあれば記載 -->
なし

## チェックリスト
- [x] タイトルを設定している
- [x] Issue へのリンクを設定している
- [x] Assignees を設定している
- [x] Labels を設定している

<!-- Create pull requestを押す前にPreviewを確認すること -->
