### PR TITLE
UsersRepository.javaの追加

### DIFF
--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/repository/cyber_wars/UsersRepository.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/repository/cyber_wars/UsersRepository.java
@@ -1,0 +1,37 @@
+package jp.ac.anan.procon.cyber_wars.infrastructure.repository.cyber_wars;
+
+import jp.ac.anan.procon.cyber_wars.domain.entity.Users;
+import jp.ac.anan.procon.cyber_wars.infrastructure.mapper.cyber_wars.UsersMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UsersRepository {
+  private final UsersMapper usersMapper;
+
+  // ユーザー登録
+  public void register(final String name, final String password) {
+    usersMapper.register(name, password);
+  }
+
+  // ユーザー取得 by ユーザーID
+  public Users fetchUserByUserId(final int userId) {
+    return usersMapper.fetchUserByUserId(userId);
+  }
+
+  // ユーザー取得 by ユーザー名
+  public Users fetchUserByName(final String name) {
+    return usersMapper.fetchUserByName(name);
+  }
+
+  // ユーザー名更新
+  public void updateName(final int userId, final String name) {
+    usersMapper.updateName(userId, name);
+  }
+
+  // ユーザーパスワード更新
+  public void updatePassword(final int userId, final String password) {
+    usersMapper.updatePassword(userId, password);
+  }
+}


### PR DESCRIPTION
## Issueへのリンク
<!-- resolve: #Issue番号 -->
resolve: #103

## 概要
Mapperを利用するためにRepositoryクラスをかます必要があるらしいので作る
[SpringBoot＋MyBatisでCRUDを書いてみた](https://qiita.com/kilvis/items/123a01d5d4fae641ad5b#2-3-mapper%E3%82%92%E5%88%A9%E7%94%A8%E3%81%99%E3%82%8Brepository%E3%82%AF%E3%83%A9%E3%82%B9%E3%81%AE%E4%BD%9C%E6%88%90)

## 作業内容
- UsersRepository.javaの追加

## 動作確認
<!-- 必要であれば実施して記載 -->
なし

## レビュワーへの参考情報
<!-- 実装上の懸念点やレビューにおける注意点などがもしあれば記載 -->
なし

## チェックリスト
- [x] タイトルを設定している
- [x] Issue へのリンクを設定している
- [x] Assignees を設定している
- [x] Labels を設定している

<!-- Create pull requestを押す前にPreviewを確認すること -->
