### PR TITLE
アタックフェーズ：課題取得APIのレスポンスのKey名の修正

### DIFF
--- a/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameAttackService.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameAttackService.java
@@ -1,6 +1,10 @@
 package jp.ac.anan.procon.cyber_wars.application.service;
 
+import static jp.ac.anan.procon.cyber_wars.application.Constant.PHP_DIRECTORY_PATH;
+
 import jakarta.servlet.http.HttpServletRequest;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import jp.ac.anan.procon.cyber_wars.application.utility.UserIdFetcher;
 import jp.ac.anan.procon.cyber_wars.domain.dto.game.attack.FetchChallengeResponse;
 import jp.ac.anan.procon.cyber_wars.domain.dto.game.attack.SendKeyRequest;
@@ -15,11 +19,6 @@ import jp.ac.anan.procon.cyber_wars.infrastructure.repository.cyber_wars.ScoresR
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.nio.file.Files;
-import java.nio.file.Paths;
-
-import static jp.ac.anan.procon.cyber_wars.application.Constant.PHP_DIRECTORY_PATH;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameAttackService.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameAttackService.java
@@ -1,10 +1,6 @@
 package jp.ac.anan.procon.cyber_wars.application.service;
 
-import static jp.ac.anan.procon.cyber_wars.application.Constant.PHP_DIRECTORY_PATH;
-
 import jakarta.servlet.http.HttpServletRequest;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import jp.ac.anan.procon.cyber_wars.application.utility.UserIdFetcher;
 import jp.ac.anan.procon.cyber_wars.domain.dto.game.attack.FetchChallengeResponse;
 import jp.ac.anan.procon.cyber_wars.domain.dto.game.attack.SendKeyRequest;
@@ -19,6 +15,11 @@ import jp.ac.anan.procon.cyber_wars.infrastructure.repository.cyber_wars.ScoresR
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static jp.ac.anan.procon.cyber_wars.application.Constant.PHP_DIRECTORY_PATH;
 
 @Service
 @RequiredArgsConstructor
@@ -53,7 +54,7 @@ public class GameAttackService {
         roomId,
         targetCode,
         challenges.getGoal(),
-        challenges.getChoice().split(","),
+        challenges.getChoices().split(","),
         challenges.getHint(),
         scoresRepository.fetchScore((byte) 1));
   }

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/game/attack/FetchChallengeResponse.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/game/attack/FetchChallengeResponse.java
@@ -1,4 +1,4 @@
 package jp.ac.anan.procon.cyber_wars.domain.dto.game.attack;
 
 public record FetchChallengeResponse(
-    int targetPath, String code, String goal, String[] choice, String hint, Short hintScore) {}
+    int targetPath, String code, String goal, String[] choices, String hint, Short hintScore) {}

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/domain/entity/Challenges.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/domain/entity/Challenges.java
@@ -11,7 +11,7 @@ public class Challenges {
 
   private final String goal;
 
-  private final String choice;
+  private final String choices;
 
   private final String hint;
 

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/ChallengesMapper.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/ChallengesMapper.java
@@ -24,7 +24,7 @@ public interface ChallengesMapper {
       value = {
         @Result(column = "challenge_id", property = "challengeId"),
         @Result(column = "goal", property = "goal"),
-        @Result(column = "choice", property = "choice"),
+        @Result(column = "choices", property = "choices"),
         @Result(column = "hint", property = "hint"),
         @Result(column = "explanation", property = "explanation"),
         @Result(column = "target_table", property = "targetTable")


### PR DESCRIPTION
## Issueへのリンク
<!-- resolve: #Issue番号 -->
resolve: #258 

## 概要
アタックフェーズ：課題取得APIのレスポンスのKey名がchoicesのはずがchoiceになっている

## 作業内容
- 課題取得APIのレスポンスのKey名の修正

## 動作確認
<!-- 必要であれば実施して記載 -->
なし

## レビュワーへの参考情報
<!-- 実装上の懸念点やレビューにおける注意点などがもしあれば記載 -->
なし
