### PR TITLE
MariaDBのUTCが87秒早いバグの調整

### DIFF
--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/RoomsMapper.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/RoomsMapper.java
@@ -1,7 +1,5 @@
 package jp.ac.anan.procon.cyber_wars.infrastructure.mapper.cyber_wars;
 
-import java.sql.Timestamp;
-import java.util.List;
 import jp.ac.anan.procon.cyber_wars.domain.entity.Rooms;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
@@ -10,6 +8,9 @@ import org.apache.ibatis.annotations.ResultMap;
 import org.apache.ibatis.annotations.Results;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
+
+import java.sql.Timestamp;
+import java.util.List;
 
 @Mapper
 public interface RoomsMapper {
@@ -132,7 +133,7 @@ public interface RoomsMapper {
       UPDATE
         rooms
       SET
-        start_time = CURRENT_TIMESTAMP()
+        start_time = CURRENT_TIMESTAMP() - INTERVAL 87 SECOND
       WHERE
         room_id = #{roomId}
       """)

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/RoomsMapper.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/RoomsMapper.java
@@ -1,5 +1,7 @@
 package jp.ac.anan.procon.cyber_wars.infrastructure.mapper.cyber_wars;
 
+import java.sql.Timestamp;
+import java.util.List;
 import jp.ac.anan.procon.cyber_wars.domain.entity.Rooms;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
@@ -8,9 +10,6 @@ import org.apache.ibatis.annotations.ResultMap;
 import org.apache.ibatis.annotations.Results;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
-
-import java.sql.Timestamp;
-import java.util.List;
 
 @Mapper
 public interface RoomsMapper {


### PR DESCRIPTION
## Issueへのリンク
<!-- resolve: #Issue番号 -->
resolve: #263 

## 概要
MariaDBのUTCが87秒早いバグの調整

## 作業内容
- オフセットで87秒遅らせる

## 動作確認
<!-- 必要であれば実施して記載 -->
なし

## レビュワーへの参考情報
<!-- 実装上の懸念点やレビューにおける注意点などがもしあれば記載 -->
なし
