### PR TITLE
あらゆるバグの修正

### DIFF
--- a/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/DebugService.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/DebugService.java
@@ -1,5 +1,6 @@
 package jp.ac.anan.procon.cyber_wars.application.service;
 
+import jp.ac.anan.procon.cyber_wars.application.utility.ArrayToStringConverter;
 import jp.ac.anan.procon.cyber_wars.domain.dto.debug.EnableChallengesRequest;
 import jp.ac.anan.procon.cyber_wars.infrastructure.repository.cyber_wars.ChallengesRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class DebugService {
   private final ChallengesRepository challengesRepository;
+  private final ArrayToStringConverter arrayToStringConverter;
 
   // 課題有効化
   public void enableChallenges(final EnableChallengesRequest enableChallengesRequest) {
@@ -19,13 +21,8 @@ public class DebugService {
       challengesRepository.enableAllChallenges();
     } else {
       challengesRepository.disableAllChallenges();
-
-      final StringBuilder challengeIds = new StringBuilder();
-      for (int challengeId : enableChallengesRequest.challengeIds()) {
-        challengeIds.append(",").append(challengeId);
-      }
-
-      challengesRepository.enableChallenges(challengeIds.substring(1));
+      challengesRepository.enableChallenges(
+          arrayToStringConverter.convert(enableChallengesRequest.challengeIds()));
     }
   }
 }

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameAttackService.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameAttackService.java
@@ -1,6 +1,10 @@
 package jp.ac.anan.procon.cyber_wars.application.service;
 
+import static jp.ac.anan.procon.cyber_wars.application.Constant.PHP_DIRECTORY_PATH;
+
 import jakarta.servlet.http.HttpServletRequest;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import jp.ac.anan.procon.cyber_wars.application.utility.KeySender;
 import jp.ac.anan.procon.cyber_wars.application.utility.UserIdFetcher;
 import jp.ac.anan.procon.cyber_wars.domain.dto.game.attack.FetchChallengeResponse;
@@ -17,11 +21,6 @@ import jp.ac.anan.procon.cyber_wars.infrastructure.repository.cyber_wars.ScoresR
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.nio.file.Files;
-import java.nio.file.Paths;
-
-import static jp.ac.anan.procon.cyber_wars.application.Constant.PHP_DIRECTORY_PATH;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameAttackService.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameAttackService.java
@@ -32,7 +32,7 @@ public class GameAttackService {
   private final TableRepository tableRepository;
   private final UserIdFetcher userIdFetcher;
 
-  // 課題取得
+  // アタックフェーズ：課題取得
   public FetchChallengeResponse fetchChallenge(final HttpServletRequest httpServletRequest) {
     final int roomId = allocationsRepository.fetchRoomId(userIdFetcher.fetch(httpServletRequest));
     final int challengeId = roomsRepository.fetchChallengeId(roomId);
@@ -55,18 +55,18 @@ public class GameAttackService {
         challenges.getGoal(),
         challenges.getChoices().split(","),
         challenges.getHint(),
-        scoresRepository.fetchScore((byte) 1));
+        scoresRepository.fetchScore((byte) 2));
   }
 
-  // ヒント使用
+  // アタックフェーズ：ヒント使用
   public void useHint(final HttpServletRequest httpServletRequest) {
     final int userId = userIdFetcher.fetch(httpServletRequest);
     final int roomId = allocationsRepository.fetchRoomId(userId);
 
-    gamesRepository.addScore(userId, roomId, roomsRepository.fetchChallengeId(roomId), (byte) 1);
+    gamesRepository.addScore(userId, roomId, roomsRepository.fetchChallengeId(roomId), (byte) 2);
   }
 
-  // フラグ送信
+  // アタックフェーズ：キー送信
   public SendKeyResponse sendKey(
       final SendKeyRequest sendKeyRequest, final HttpServletRequest httpServletRequest) {
     final int userId = userIdFetcher.fetch(httpServletRequest);
@@ -74,7 +74,7 @@ public class GameAttackService {
     final int challengeId = roomsRepository.fetchChallengeId(roomId);
     String key = sendKeyRequest.key();
 
-    // フラグにKEY{が含まれない場合
+    // キーにKEY{が含まれない場合
     if (!key.contains("KEY{")) {
       key = "KEY{" + key + "}";
     }
@@ -89,12 +89,12 @@ public class GameAttackService {
     }
 
     // ゲームが存在する場合
-    if (gamesRepository.fetchGame(userId, roomId, challengeId, (byte) 0) != null) {
+    if (gamesRepository.fetchGame(userId, roomId, challengeId, (byte) 1) != null) {
       return new SendKeyResponse(false, true, null);
     }
 
-    gamesRepository.addScore(userId, roomId, challengeId, (byte) 0);
+    gamesRepository.addScore(userId, roomId, challengeId, (byte) 1);
 
-    return new SendKeyResponse(true, true, scoresRepository.fetchScore((byte) 0));
+    return new SendKeyResponse(true, true, scoresRepository.fetchScore((byte) 1));
   }
 }

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameAttackService.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameAttackService.java
@@ -1,14 +1,12 @@
 package jp.ac.anan.procon.cyber_wars.application.service;
 
-import static jp.ac.anan.procon.cyber_wars.application.Constant.PHP_DIRECTORY_PATH;
-
 import jakarta.servlet.http.HttpServletRequest;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import jp.ac.anan.procon.cyber_wars.application.utility.KeySender;
 import jp.ac.anan.procon.cyber_wars.application.utility.UserIdFetcher;
 import jp.ac.anan.procon.cyber_wars.domain.dto.game.attack.FetchChallengeResponse;
 import jp.ac.anan.procon.cyber_wars.domain.dto.game.attack.SendKeyRequest;
 import jp.ac.anan.procon.cyber_wars.domain.dto.game.attack.SendKeyResponse;
+import jp.ac.anan.procon.cyber_wars.domain.dto.utility.SendResponse;
 import jp.ac.anan.procon.cyber_wars.domain.entity.Challenges;
 import jp.ac.anan.procon.cyber_wars.infrastructure.repository.challenge.TableRepository;
 import jp.ac.anan.procon.cyber_wars.infrastructure.repository.cyber_wars.AllocationsRepository;
@@ -19,6 +17,11 @@ import jp.ac.anan.procon.cyber_wars.infrastructure.repository.cyber_wars.ScoresR
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static jp.ac.anan.procon.cyber_wars.application.Constant.PHP_DIRECTORY_PATH;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +34,7 @@ public class GameAttackService {
   private final ScoresRepository scoresRepository;
   private final TableRepository tableRepository;
   private final UserIdFetcher userIdFetcher;
+  private final KeySender keySender;
 
   // アタックフェーズ：課題取得
   public FetchChallengeResponse fetchChallenge(final HttpServletRequest httpServletRequest) {
@@ -63,38 +67,16 @@ public class GameAttackService {
     final int userId = userIdFetcher.fetch(httpServletRequest);
     final int roomId = allocationsRepository.fetchRoomId(userId);
 
-    gamesRepository.addScore(userId, roomId, roomsRepository.fetchChallengeId(roomId), (byte) 2);
+    gamesRepository.addScore(
+        userId, roomId, roomsRepository.fetchChallengeId(roomId), (byte) 2, (short) 100);
   }
 
   // アタックフェーズ：キー送信
   public SendKeyResponse sendKey(
       final SendKeyRequest sendKeyRequest, final HttpServletRequest httpServletRequest) {
-    final int userId = userIdFetcher.fetch(httpServletRequest);
-    final int roomId = allocationsRepository.fetchRoomId(userId);
-    final int challengeId = roomsRepository.fetchChallengeId(roomId);
-    String key = sendKeyRequest.key();
+    final SendResponse sendResponse =
+        keySender.send(sendKeyRequest.key(), "attack", httpServletRequest);
 
-    // キーにKEY{が含まれない場合
-    if (!key.contains("KEY{")) {
-      key = "KEY{" + key + "}";
-    }
-
-    // レコードが存在しない場合
-    if (tableRepository.fetchRecord(
-            challengesRepository.fetchTargetTable(roomsRepository.fetchChallengeId(roomId))
-                + roomId,
-            key)
-        == null) {
-      return new SendKeyResponse(null, false, null);
-    }
-
-    // ゲームが存在する場合
-    if (gamesRepository.fetchGame(userId, roomId, challengeId, (byte) 1) != null) {
-      return new SendKeyResponse(false, true, null);
-    }
-
-    gamesRepository.addScore(userId, roomId, challengeId, (byte) 1);
-
-    return new SendKeyResponse(true, true, scoresRepository.fetchScore((byte) 1));
+    return new SendKeyResponse(sendResponse.valid(), sendResponse.correct(), sendResponse.score());
   }
 }

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameBattleService.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameBattleService.java
@@ -1,6 +1,10 @@
 package jp.ac.anan.procon.cyber_wars.application.service;
 
+import static jp.ac.anan.procon.cyber_wars.application.Constant.PHP_DIRECTORY_PATH;
+
 import jakarta.servlet.http.HttpServletRequest;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import jp.ac.anan.procon.cyber_wars.application.utility.KeySender;
 import jp.ac.anan.procon.cyber_wars.application.utility.TableUtility;
 import jp.ac.anan.procon.cyber_wars.application.utility.UserIdFetcher;
@@ -17,11 +21,6 @@ import jp.ac.anan.procon.cyber_wars.infrastructure.repository.cyber_wars.ScoresR
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.nio.file.Files;
-import java.nio.file.Paths;
-
-import static jp.ac.anan.procon.cyber_wars.application.Constant.PHP_DIRECTORY_PATH;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameDefenceService.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameDefenceService.java
@@ -9,6 +9,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import jp.ac.anan.procon.cyber_wars.application.utility.CodeReplacer;
 import jp.ac.anan.procon.cyber_wars.application.utility.UserIdFetcher;
+import jp.ac.anan.procon.cyber_wars.domain.dto.game.defence.FetchRevisionPathResponse;
 import jp.ac.anan.procon.cyber_wars.domain.dto.game.defence.SendCodeRequest;
 import jp.ac.anan.procon.cyber_wars.domain.dto.game.defence.SendCodeResponse;
 import jp.ac.anan.procon.cyber_wars.infrastructure.repository.cyber_wars.AllocationsRepository;
@@ -28,7 +29,12 @@ public class GameDefenceService {
   private final UserIdFetcher userIdFetcher;
   private final CodeReplacer codeReplacer;
 
-  // コード送信
+  // ディフェンスフェーズ：修正課題パス取得
+  public FetchRevisionPathResponse fetchRevisionPath(final HttpServletRequest httpServletRequest) {
+    return new FetchRevisionPathResponse(userIdFetcher.fetch(httpServletRequest));
+  }
+
+  // ディフェンスフェーズ：コード送信
   public SendCodeResponse sendCode(
       final SendCodeRequest sendCodeRequest, final HttpServletRequest httpServletRequest) {
     final int userId = userIdFetcher.fetch(httpServletRequest);

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameService.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameService.java
@@ -1,6 +1,12 @@
 package jp.ac.anan.procon.cyber_wars.application.service;
 
+import static jp.ac.anan.procon.cyber_wars.application.Constant.PHP_DIRECTORY_PATH;
+
 import jakarta.servlet.http.HttpServletRequest;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import jp.ac.anan.procon.cyber_wars.application.utility.ArrayToStringConverter;
 import jp.ac.anan.procon.cyber_wars.application.utility.CodeReplacer;
 import jp.ac.anan.procon.cyber_wars.application.utility.TableUtility;
@@ -19,13 +25,6 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.io.FileUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
-import static jp.ac.anan.procon.cyber_wars.application.Constant.PHP_DIRECTORY_PATH;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameService.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameService.java
@@ -7,10 +7,12 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import jp.ac.anan.procon.cyber_wars.application.utility.ArrayToStringConverter;
 import jp.ac.anan.procon.cyber_wars.application.utility.CodeReplacer;
 import jp.ac.anan.procon.cyber_wars.application.utility.TableUtility;
 import jp.ac.anan.procon.cyber_wars.application.utility.UserIdFetcher;
 import jp.ac.anan.procon.cyber_wars.domain.dto.game.EndGameRequest;
+import jp.ac.anan.procon.cyber_wars.domain.dto.game.EndGameResponse;
 import jp.ac.anan.procon.cyber_wars.domain.dto.game.FetchExplanationResponse;
 import jp.ac.anan.procon.cyber_wars.domain.dto.game.FetchScoresResponse;
 import jp.ac.anan.procon.cyber_wars.domain.dto.game.FetchStartTimeResponse;
@@ -36,6 +38,7 @@ public class GameService {
   private final UserIdFetcher userIdFetcher;
   private final TableUtility tableUtility;
   private final CodeReplacer codeReplacer;
+  private final ArrayToStringConverter arrayToStringConverter;
 
   // ゲーム開始
   public void start(final HttpServletRequest httpServletRequest) {
@@ -45,6 +48,11 @@ public class GameService {
 
     roomsRepository.close(roomId);
     roomsRepository.updateStartTime(roomId);
+
+    // ユーザーがホストである場合
+    if (allocationsRepository.isHost(userId)) {
+      gamesRepository.addScore(userId, roomId, challengeId, (byte) 0);
+    }
 
     try {
       final String challengeDirectoryPath = PHP_DIRECTORY_PATH + "challenge/" + challengeId;
@@ -64,20 +72,6 @@ public class GameService {
       Files.copy(challengeEnvPath, Paths.get(targetDirectoryPath + ".env"));
       FileUtils.copyDirectory(challengeVendorFile, new File(targetDirectoryPath + "vendor"));
 
-      final String revisionDirectoryPath = gameDirectoryPath + "/revision/";
-
-      Files.createDirectory(Paths.get(revisionDirectoryPath));
-      Files.copy(challengePhpPath, Paths.get(revisionDirectoryPath + userId + ".php"));
-      Files.copy(
-          challengePhpPath,
-          Paths.get(
-              revisionDirectoryPath
-                  + allocationsRepository.fetchOpponentUserId(userId, roomId)
-                  + ".php"));
-      Files.copy(challengeCssPath, Paths.get(revisionDirectoryPath + "style.css"));
-      Files.copy(challengeEnvPath, Paths.get(revisionDirectoryPath + ".env"));
-      FileUtils.copyDirectory(challengeVendorFile, new File(revisionDirectoryPath + "vendor"));
-
       final String originalTargetTable = challengesRepository.fetchTargetTable(challengeId);
 
       // 標的テーブルが存在する場合
@@ -95,6 +89,20 @@ public class GameService {
         Files.createFile(targetKeyPath);
         Files.writeString(targetKeyPath, tableUtility.generateKey());
       }
+
+      final String revisionDirectoryPath = gameDirectoryPath + "/revision/";
+
+      Files.createDirectory(Paths.get(revisionDirectoryPath));
+      Files.copy(targetPhpPath, Paths.get(revisionDirectoryPath + userId + ".php"));
+      Files.copy(
+          targetPhpPath,
+          Paths.get(
+              revisionDirectoryPath
+                  + allocationsRepository.fetchOpponentUserId(userId, roomId)
+                  + ".php"));
+      Files.copy(challengeCssPath, Paths.get(revisionDirectoryPath + "style.css"));
+      Files.copy(challengeEnvPath, Paths.get(revisionDirectoryPath + ".env"));
+      FileUtils.copyDirectory(challengeVendorFile, new File(revisionDirectoryPath + "vendor"));
     } catch (final Exception exception) {
       exception.printStackTrace();
     }
@@ -130,20 +138,37 @@ public class GameService {
   }
 
   // ゲーム終了
-  public void endGame(
+  public EndGameResponse endGame(
       final EndGameRequest endGameRequest, final HttpServletRequest httpServletRequest) {
     final int roomId = allocationsRepository.fetchRoomId(userIdFetcher.fetch(httpServletRequest));
 
-    if (endGameRequest.rematch()) {
-      try {
-        FileUtils.forceDelete(new File(PHP_DIRECTORY_PATH + "game/" + roomId));
-      } catch (final Exception exception) {
-        exception.printStackTrace();
-      }
-    }
-
     tableRepository.drop(
         challengesRepository.fetchTargetTable(roomsRepository.fetchChallengeId(roomId)) + roomId);
-    roomsRepository.updateChallengeId(roomId);
+
+    // 再戦しない場合
+    if (!endGameRequest.rematch()) {
+      return new EndGameResponse(null);
+    }
+
+    final Integer unusedChallengeId =
+        challengesRepository.fetchUnusedChallengeId(
+            arrayToStringConverter.convert(gamesRepository.fetchChallengeIds(roomId)));
+
+    // 未使用課題IDが存在しない場合
+    if (unusedChallengeId == null) {
+      return new EndGameResponse(false);
+    }
+
+    roomsRepository.updateChallengeId(roomId, unusedChallengeId);
+
+    try {
+      FileUtils.forceDelete(new File(PHP_DIRECTORY_PATH + "game/" + roomId));
+    } catch (final Exception exception) {
+      exception.printStackTrace();
+
+      return new EndGameResponse(false);
+    }
+
+    return new EndGameResponse(true);
   }
 }

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameService.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/application/service/GameService.java
@@ -1,12 +1,6 @@
 package jp.ac.anan.procon.cyber_wars.application.service;
 
-import static jp.ac.anan.procon.cyber_wars.application.Constant.PHP_DIRECTORY_PATH;
-
 import jakarta.servlet.http.HttpServletRequest;
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import jp.ac.anan.procon.cyber_wars.application.utility.ArrayToStringConverter;
 import jp.ac.anan.procon.cyber_wars.application.utility.CodeReplacer;
 import jp.ac.anan.procon.cyber_wars.application.utility.TableUtility;
@@ -25,6 +19,13 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.io.FileUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static jp.ac.anan.procon.cyber_wars.application.Constant.PHP_DIRECTORY_PATH;
 
 @Service
 @RequiredArgsConstructor
@@ -51,7 +52,7 @@ public class GameService {
 
     // ユーザーがホストである場合
     if (allocationsRepository.isHost(userId)) {
-      gamesRepository.addScore(userId, roomId, challengeId, (byte) 0);
+      gamesRepository.addGame(userId, roomId, challengeId, (byte) 0);
     }
 
     try {

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/application/utility/ArrayToStringConverter.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/application/utility/ArrayToStringConverter.java
@@ -1,0 +1,17 @@
+package jp.ac.anan.procon.cyber_wars.application.utility;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ArrayToStringConverter {
+  // 文字列フォーマット
+  public String convert(final int[] array) {
+    final StringBuilder string = new StringBuilder();
+
+    for (final int element : array) {
+      string.append(",").append(element);
+    }
+
+    return string.substring(1);
+  }
+}

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/application/utility/KeySender.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/application/utility/KeySender.java
@@ -1,0 +1,71 @@
+package jp.ac.anan.procon.cyber_wars.application.utility;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jp.ac.anan.procon.cyber_wars.domain.dto.utility.SendResponse;
+import jp.ac.anan.procon.cyber_wars.domain.pojo.TimeLimit;
+import jp.ac.anan.procon.cyber_wars.infrastructure.repository.challenge.TableRepository;
+import jp.ac.anan.procon.cyber_wars.infrastructure.repository.cyber_wars.AllocationsRepository;
+import jp.ac.anan.procon.cyber_wars.infrastructure.repository.cyber_wars.ChallengesRepository;
+import jp.ac.anan.procon.cyber_wars.infrastructure.repository.cyber_wars.GamesRepository;
+import jp.ac.anan.procon.cyber_wars.infrastructure.repository.cyber_wars.RoomsRepository;
+import jp.ac.anan.procon.cyber_wars.infrastructure.repository.cyber_wars.ScoresRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KeySender {
+  private final RoomsRepository roomsRepository;
+  private final AllocationsRepository allocationsRepository;
+  private final GamesRepository gamesRepository;
+  private final ChallengesRepository challengesRepository;
+  private final ScoresRepository scoresRepository;
+  private final TableRepository tableRepository;
+  private final UserIdFetcher userIdFetcher;
+
+  // キー送信
+  public SendResponse send(
+      String key, final String phase, final HttpServletRequest httpServletRequest) {
+    final int userId = userIdFetcher.fetch(httpServletRequest);
+    final int roomId = allocationsRepository.fetchRoomId(userId);
+    final int challengeId = roomsRepository.fetchChallengeId(roomId);
+
+    // キーにFLAG{が含まれない場合
+    if (!key.contains("KEY{")) {
+      key = "KEY{" + key + "}";
+    }
+
+    // レコードが存在しない場合
+    if (tableRepository.fetchRecord(
+            challengesRepository.fetchTargetTable(roomsRepository.fetchChallengeId(roomId))
+                + roomId,
+            key)
+        == null) {
+      return new SendResponse(null, false, null);
+    }
+
+    byte gameId = 1;
+    short timeOffset = 0;
+    final TimeLimit timeLimit = roomsRepository.fetchTimeLimit(roomId);
+
+    // バトルフェーズである場合
+    if (phase.equals("battle")) {
+      gameId = 5;
+      timeOffset = (short) (timeLimit.attackPhaseTimeLimit() + timeLimit.defencePhaseTimeLimit());
+    }
+
+    // ゲームが存在する場合
+    if (gamesRepository.fetchGame(userId, roomId, challengeId, gameId) != null) {
+      return new SendResponse(false, true, null);
+    }
+
+    gamesRepository.addScore(
+        userId,
+        roomId,
+        challengeId,
+        gameId,
+        roomsRepository.fetchScoreMultiplier(roomId, phase, timeOffset));
+
+    return new SendResponse(true, true, scoresRepository.fetchScore(gameId));
+  }
+}

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/application/utility/RandomGenerator.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/application/utility/RandomGenerator.java
@@ -33,7 +33,7 @@ public class RandomGenerator {
     return inviteId;
   }
 
-  // フラグ生成
+  // キー生成
   public String generateKey() {
     final StringBuilder key = new StringBuilder();
     final Random random = new Random();

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/application/utility/TableUtility.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/application/utility/TableUtility.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 public class TableUtility {
   private final RandomGenerator randomGenerator;
 
-  // フラグ生成
+  // キー生成
   public String generateKey() {
     return "KEY{" + randomGenerator.generateKey() + "}";
   }

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/game/EndGameResponse.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/game/EndGameResponse.java
@@ -1,0 +1,3 @@
+package jp.ac.anan.procon.cyber_wars.domain.dto.game;
+
+public record EndGameResponse(Boolean success) {}

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/game/battle/FetchRevisionResponse.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/game/battle/FetchRevisionResponse.java
@@ -1,3 +1,3 @@
 package jp.ac.anan.procon.cyber_wars.domain.dto.game.battle;
 
-public record FetchRevisionResponse(int revisionPath, String code) {}
+public record FetchRevisionResponse(int opponentRevisionPath, String code) {}

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/game/defence/FetchRevisionPathResponse.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/game/defence/FetchRevisionPathResponse.java
@@ -1,0 +1,3 @@
+package jp.ac.anan.procon.cyber_wars.domain.dto.game.defence;
+
+public record FetchRevisionPathResponse(int myRevisionPath) {}

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/room/CreateRequest.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/room/CreateRequest.java
@@ -1,0 +1,5 @@
+package jp.ac.anan.procon.cyber_wars.domain.dto.room;
+
+import jp.ac.anan.procon.cyber_wars.domain.pojo.TimeLimit;
+
+public record CreateRequest(TimeLimit timeLimit) {}

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/room/FetchInformationResponse.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/room/FetchInformationResponse.java
@@ -1,3 +1,6 @@
 package jp.ac.anan.procon.cyber_wars.domain.dto.room;
 
-public record FetchInformationResponse(String opponentName, boolean host, boolean started) {}
+import jp.ac.anan.procon.cyber_wars.domain.pojo.TimeLimit;
+
+public record FetchInformationResponse(
+    String opponentName, boolean host, TimeLimit timeLimit, boolean started) {}

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/room/UpdateTimeLimitRequest.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/room/UpdateTimeLimitRequest.java
@@ -1,0 +1,5 @@
+package jp.ac.anan.procon.cyber_wars.domain.dto.room;
+
+import jp.ac.anan.procon.cyber_wars.domain.pojo.TimeLimit;
+
+public record UpdateTimeLimitRequest(TimeLimit timeLimit) {}

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/utility/SendResponse.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/domain/dto/utility/SendResponse.java
@@ -1,0 +1,3 @@
+package jp.ac.anan.procon.cyber_wars.domain.dto.utility;
+
+public record SendResponse(Boolean valid, boolean correct, Short score) {}

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/domain/entity/Games.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/domain/entity/Games.java
@@ -13,5 +13,5 @@ public class Games {
 
   @Id private final int userId;
 
-  @Id private final byte scoreType;
+  @Id private final byte gameId;
 }

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/domain/entity/Games.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/domain/entity/Games.java
@@ -14,4 +14,6 @@ public class Games {
   @Id private final int userId;
 
   @Id private final byte gameId;
+
+  private final short scoreMultiplier;
 }

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/domain/entity/Rooms.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/domain/entity/Rooms.java
@@ -16,11 +16,11 @@ public class Rooms {
 
   private final Timestamp startTime;
 
-  private final short attack_phase_time_limit;
+  private final short attackPhaseTimeLimit;
 
-  private final short defence_phase_time_limit;
+  private final short defencePhaseTimeLimit;
 
-  private final short battle_phase_time_limit;
+  private final short battlePhaseTimeLimit;
 
   private final boolean active;
 }

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/domain/entity/Rooms.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/domain/entity/Rooms.java
@@ -16,5 +16,11 @@ public class Rooms {
 
   private final Timestamp startTime;
 
+  private final short attack_phase_time_limit;
+
+  private final short defence_phase_time_limit;
+
+  private final short battle_phase_time_limit;
+
   private final boolean active;
 }

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/domain/pojo/TimeLimit.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/domain/pojo/TimeLimit.java
@@ -1,0 +1,4 @@
+package jp.ac.anan.procon.cyber_wars.domain.pojo;
+
+public record TimeLimit(
+    short attackPhaseTimeLimit, short defencePhaseTimeLimit, short battlePhaseTimeLimit) {}

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/challenge/TableMapper.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/challenge/TableMapper.java
@@ -33,7 +33,7 @@ public interface TableMapper {
       """)
   void create(final String originalTargetTable, final String targetTable);
 
-  // フラグ更新
+  // キー更新
   @Update(
       """
       UPDATE

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/AllocationsMapper.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/AllocationsMapper.java
@@ -11,7 +11,9 @@ public interface AllocationsMapper {
   @Insert(
       """
       INSERT INTO
-        allocations(room_id, user_id, host)
+        allocations(
+          room_id, user_id, host
+        )
       SELECT
         room_id, #{userId}, #{host}
       FROM

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/ChallengesMapper.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/ChallengesMapper.java
@@ -31,6 +31,42 @@ public interface ChallengesMapper {
       })
   Challenges fetchChallenge(final int challengeId);
 
+  // 有効課題ID取得
+  @Select(
+      """
+      SELECT
+        challenge_id
+      FROM
+        challenges
+      WHERE
+        available = TRUE
+      ORDER BY
+        RAND()
+      LIMIT
+        1
+      """)
+  int fetchAvailableChallengeId();
+
+  // 未使用課題ID取得
+  @Select(
+      """
+      SELECT
+        challenge_id
+      FROM
+        challenges
+      WHERE
+        challenge_id = #{challengeId}
+      AND
+        challenge_id
+      NOT IN
+        (${challengeIds})
+      ORDER BY
+        RAND()
+      LIMIT
+        1
+      """)
+  Integer fetchUnusedChallengeId(final String challengeIds);
+
   // 解説取得
   @Select(
       """

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/ChallengesMapper.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/ChallengesMapper.java
@@ -58,8 +58,9 @@ public interface ChallengesMapper {
         challenge_id = #{challengeId}
       AND
         challenge_id
-      NOT IN
-        (${challengeIds})
+      NOT IN(
+        ${challengeIds}
+      )
       ORDER BY
         RAND()
       LIMIT
@@ -118,8 +119,9 @@ public interface ChallengesMapper {
         available = TRUE
       WHERE
         challenge_id
-      IN
-        (${challengeIds})
+      IN(
+        ${challengeIds}
+      )
       """)
   void enableChallenges(final String challengeIds);
 }

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/GamesMapper.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/GamesMapper.java
@@ -9,15 +9,36 @@ import org.apache.ibatis.annotations.Select;
 
 @Mapper
 public interface GamesMapper {
+  // ゲーム追加
+  @Insert(
+      """
+      INSERT INTO
+        games(
+          room_id,challenge_id, user_id, game_id
+        )
+      VALUES(
+        #{roomId},#{challengeId}, #{userId}, #{gameId}
+      )
+      """)
+  void addGame(final int userId, final int challengeId, final int roomId, final byte gameId);
+
   // スコア追加
   @Insert(
       """
       INSERT INTO
-        games(room_id,challenge_id, user_id, game_id)
-      VALUES
-        (#{roomId},#{challengeId}, #{userId}, #{gameId})
+        games(
+          room_id,challenge_id, user_id, game_id,score_multiplier
+        )
+      VALUES(
+        #{roomId},#{challengeId}, #{userId}, #{gameId},#{scoreMultiplier}
+      )
       """)
-  void addScore(final int userId, final int challengeId, final int roomId, final byte gameId);
+  void addScore(
+      final int userId,
+      final int challengeId,
+      final int roomId,
+      final byte gameId,
+      final short scoreMultiplier);
 
   // ゲーム取得
   @Select(
@@ -41,7 +62,8 @@ public interface GamesMapper {
         @Result(column = "room_id", property = "roomId"),
         @Result(column = "challenge_id", property = "challengeId"),
         @Result(column = "user_id", property = "userId"),
-        @Result(column = "game_id", property = "gameId")
+        @Result(column = "game_id", property = "gameId"),
+        @Result(column = "score_multiplier", property = "scoreMultiplier")
       })
   Games fetchGame(final int userId, final int roomId, final int challengeId, final byte gameId);
 
@@ -63,7 +85,14 @@ public interface GamesMapper {
   @Select(
       """
       SELECT
-        COALESCE(SUM(score), 0)
+        COALESCE(
+          FLOOR(
+            SUM(
+              score * score_multiplier
+            ) / 100
+          ),
+          0
+        )
       FROM
         games
       NATURAL JOIN

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/GamesMapper.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/GamesMapper.java
@@ -13,11 +13,11 @@ public interface GamesMapper {
   @Insert(
       """
       INSERT INTO
-        games(room_id,challenge_id, user_id, score_type)
+        games(room_id,challenge_id, user_id, game_id)
       VALUES
-        (#{roomId},#{challengeId}, #{userId}, #{scoreType})
+        (#{roomId},#{challengeId}, #{userId}, #{gameId})
       """)
-  void addScore(final int userId, final int challengeId, final int roomId, final byte scoreType);
+  void addScore(final int userId, final int challengeId, final int roomId, final byte gameId);
 
   // ゲーム取得
   @Select(
@@ -33,7 +33,7 @@ public interface GamesMapper {
       AND
         user_id = #{userId}
       AND
-        score_type = #{scoreType}
+        game_id = #{gameId}
       """)
   @Results(
       id = "Games",
@@ -41,9 +41,23 @@ public interface GamesMapper {
         @Result(column = "room_id", property = "roomId"),
         @Result(column = "challenge_id", property = "challengeId"),
         @Result(column = "user_id", property = "userId"),
-        @Result(column = "score_type", property = "scoreType")
+        @Result(column = "game_id", property = "gameId")
       })
-  Games fetchGame(final int userId, final int roomId, final int challengeId, final byte scoreType);
+  Games fetchGame(final int userId, final int roomId, final int challengeId, final byte gameId);
+
+  // 課題ID取得
+  @Select(
+      """
+      SELECT
+        challenge_id
+      FROM
+        games
+      WHERE
+        room_id = #{roomId}
+      AND
+        game_id = 0
+      """)
+  int[] fetchChallengeIds(final int roomId);
 
   // スコア取得
   @Select(

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/RoomsMapper.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/RoomsMapper.java
@@ -18,16 +18,26 @@ public interface RoomsMapper {
   @Insert(
       """
       INSERT INTO
-        rooms(invite_id, challenge_id, attack_phase_time_limit, defence_phase_time_limit, battle_phase_time_limit)
+        rooms(
+          invite_id,
+          challenge_id,
+          attack_phase_time_limit,
+          defence_phase_time_limit,
+          battle_phase_time_limit
+        )
       VALUES
-        (#{inviteId}, #{challengeId}, #{attack_phase_time_limit}, #{defence_phase_time_limit}, #{battle_phase_time_limit})
+        (#{inviteId},
+        #{challengeId},
+        #{attackPhaseTimeLimit},
+        #{defencePhaseTimeLimit},
+        #{battlePhaseTimeLimit})
       """)
   void create(
       final short inviteId,
       final int challengeId,
-      final short attack_phase_time_limit,
-      final short defence_phase_time_limit,
-      final short battle_phase_time_limit);
+      final short attackPhaseTimeLimit,
+      final short defencePhaseTimeLimit,
+      final short battlePhaseTimeLimit);
 
   // ルーム取得 by 招待ID
   @Select(

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/RoomsMapper.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/RoomsMapper.java
@@ -1,5 +1,7 @@
 package jp.ac.anan.procon.cyber_wars.infrastructure.mapper.cyber_wars;
 
+import java.sql.Timestamp;
+import java.util.List;
 import jp.ac.anan.procon.cyber_wars.domain.entity.Rooms;
 import jp.ac.anan.procon.cyber_wars.domain.pojo.TimeLimit;
 import org.apache.ibatis.annotations.Insert;
@@ -9,9 +11,6 @@ import org.apache.ibatis.annotations.ResultMap;
 import org.apache.ibatis.annotations.Results;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
-
-import java.sql.Timestamp;
-import java.util.List;
 
 @Mapper
 public interface RoomsMapper {

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/RoomsMapper.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/RoomsMapper.java
@@ -1,7 +1,5 @@
 package jp.ac.anan.procon.cyber_wars.infrastructure.mapper.cyber_wars;
 
-import java.sql.Timestamp;
-import java.util.List;
 import jp.ac.anan.procon.cyber_wars.domain.entity.Rooms;
 import jp.ac.anan.procon.cyber_wars.domain.pojo.TimeLimit;
 import org.apache.ibatis.annotations.Insert;
@@ -11,6 +9,9 @@ import org.apache.ibatis.annotations.ResultMap;
 import org.apache.ibatis.annotations.Results;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
+
+import java.sql.Timestamp;
+import java.util.List;
 
 @Mapper
 public interface RoomsMapper {
@@ -25,12 +26,13 @@ public interface RoomsMapper {
           defence_phase_time_limit,
           battle_phase_time_limit
         )
-      VALUES
-        (#{inviteId},
+      VALUES(
+        #{inviteId},
         #{challengeId},
         #{attackPhaseTimeLimit},
         #{defencePhaseTimeLimit},
-        #{battlePhaseTimeLimit})
+        #{battlePhaseTimeLimit}
+      )
       """)
   void create(
       final short inviteId,
@@ -114,6 +116,24 @@ public interface RoomsMapper {
       """)
   TimeLimit fetchTimeLimit(final int roomId);
 
+  // スコア倍率取得
+  @Select(
+      """
+      SELECT
+        100 + FLOOR(
+          (UNIX_TIMESTAMP(CURRENT_TIMESTAMP)
+          - UNIX_TIMESTAMP(start_time)
+          - #{timeOffset})
+          / ${pahse}_phase_time_limit
+          * 100
+        )
+      FROM
+        rooms
+      WHERE
+        room_id = #{roomId}
+      """)
+  short fetchScoreMultiplier(final int roomId, final String phase, final short timeOffset);
+
   // ルーム動作判定
   @Select(
       """
@@ -144,7 +164,7 @@ public interface RoomsMapper {
       UPDATE
         rooms
       SET
-        start_time = CURRENT_TIMESTAMP() - INTERVAL 77 SECOND
+        start_time = CURRENT_TIMESTAMP
       WHERE
         room_id = #{roomId}
       """)

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/RoomsMapper.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/RoomsMapper.java
@@ -3,6 +3,7 @@ package jp.ac.anan.procon.cyber_wars.infrastructure.mapper.cyber_wars;
 import java.sql.Timestamp;
 import java.util.List;
 import jp.ac.anan.procon.cyber_wars.domain.entity.Rooms;
+import jp.ac.anan.procon.cyber_wars.domain.pojo.TimeLimit;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Result;
@@ -17,19 +18,16 @@ public interface RoomsMapper {
   @Insert(
       """
       INSERT INTO
-        rooms(invite_id, challenge_id)
-      SELECT
-        #{inviteId}, challenge_id
-      FROM
-        challenges
-      WHERE
-        available = TRUE
-      ORDER BY
-        RAND()
-      LIMIT
-        1
+        rooms(invite_id, challenge_id, attack_phase_time_limit, defence_phase_time_limit, battle_phase_time_limit)
+      VALUES
+        (#{inviteId}, #{challengeId}, #{attack_phase_time_limit}, #{defence_phase_time_limit}, #{battle_phase_time_limit})
       """)
-  void create(final short inviteId);
+  void create(
+      final short inviteId,
+      final int challengeId,
+      final short attack_phase_time_limit,
+      final short defence_phase_time_limit,
+      final short battle_phase_time_limit);
 
   // ルーム取得 by 招待ID
   @Select(
@@ -50,6 +48,9 @@ public interface RoomsMapper {
         @Result(column = "invite_id", property = "inviteId"),
         @Result(column = "challenge_id", property = "challengeId"),
         @Result(column = "start_time", property = "startTime"),
+        @Result(column = "attack_phase_time_limit", property = "attackPhaseTimeLimit"),
+        @Result(column = "defence_phase_time_limit", property = "defencePhaseTimeLimit"),
+        @Result(column = "battle_phase_time_limit", property = "battlePhaseTimeLimit"),
         @Result(column = "active", property = "active")
       })
   Rooms fetchRoomByInviteId(final short inviteId);
@@ -91,6 +92,18 @@ public interface RoomsMapper {
       """)
   Timestamp fetchStartTime(final int roomId);
 
+  // 制限時間取得
+  @Select(
+      """
+      SELECT
+        attack_phase_time_limit, defence_phase_time_limit, battle_phase_time_limit
+      FROM
+        rooms
+      WHERE
+        room_id = #{roomId}
+      """)
+  TimeLimit fetchTimeLimit(final int roomId);
+
   // ルーム動作判定
   @Select(
       """
@@ -109,22 +122,11 @@ public interface RoomsMapper {
       UPDATE
         rooms
       SET
-        challenge_id = (
-          SELECT
-            challenge_id
-          FROM
-            challenges
-          WHERE
-            available = TRUE
-          ORDER BY
-            RAND()
-          LIMIT
-            1
-        )
+        challenge_id = #{challengeId}
       WHERE
         room_id = #{roomId}
       """)
-  void updateChallengeId(final int roomId);
+  void updateChallengeId(final int roomId, final int challengeId);
 
   // ゲーム開始時刻更新
   @Update(
@@ -137,6 +139,32 @@ public interface RoomsMapper {
         room_id = #{roomId}
       """)
   void updateStartTime(final int roomId);
+
+  // 制限時間更新
+  @Update(
+      """
+      UPDATE
+        rooms
+      SET
+        attack_phase_time_limit = #{timeLimit.attackPhaseTimeLimit()},
+        defence_phase_time_limit = #{timeLimit.defencePhaseTimeLimit()},
+        battle_phase_time_limit = #{timeLimit.battlePhaseTimeLimit()}
+      WHERE
+        room_id = #{roomId}
+      """)
+  void updateTimeLimit(final int roomId, final TimeLimit timeLimit);
+
+  // ルーム開放
+  @Update(
+      """
+      UPDATE
+        rooms
+      SET
+        active = TRUE
+      WHERE
+        room_id = #{roomId}
+      """)
+  void open(final int roomId);
 
   // ルーム閉鎖
   @Update(

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/ScoresMapper.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/ScoresMapper.java
@@ -13,7 +13,7 @@ public interface ScoresMapper {
       FROM
         scores
       WHERE
-        score_type = #{scoreType}
+        game_id = #{gameId}
       """)
-  short fetchScore(final byte scoreType);
+  short fetchScore(final byte gameId);
 }

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/UsersMapper.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/mapper/cyber_wars/UsersMapper.java
@@ -15,9 +15,12 @@ public interface UsersMapper {
   @Insert(
       """
       INSERT INTO
-        users(name, password)
-      VALUES
-        (#{name}, #{password})
+        users(
+          name, password
+        )
+      VALUES(
+        #{name}, #{password}
+      )
       """)
   void register(final String name, final String password);
 

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/repository/challenge/TableRepository.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/repository/challenge/TableRepository.java
@@ -19,7 +19,7 @@ public class TableRepository {
     usersTableMapper.create(originalTargetTable, targetTable);
   }
 
-  // フラグ挿入
+  // キー挿入
   public void updateKey(final String targetTable, final String key, final String mainId) {
     usersTableMapper.updateKey(targetTable, key, mainId);
   }

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/repository/cyber_wars/ChallengesRepository.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/repository/cyber_wars/ChallengesRepository.java
@@ -10,9 +10,19 @@ import org.springframework.stereotype.Repository;
 public class ChallengesRepository {
   private final ChallengesMapper challengesMapper;
 
-  // 課題取得 by 課題ID
+  // 課題取得
   public Challenges fetchChallenge(final int challengeId) {
     return challengesMapper.fetchChallenge(challengeId);
+  }
+
+  // 有効課題ID取得
+  public int fetchAvailableChallengeId() {
+    return challengesMapper.fetchAvailableChallengeId();
+  }
+
+  // 未使用課題ID取得
+  public Integer fetchUnusedChallengeId(final String challengeIds) {
+    return challengesMapper.fetchUnusedChallengeId(challengeIds);
   }
 
   // 解説取得

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/repository/cyber_wars/GamesRepository.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/repository/cyber_wars/GamesRepository.java
@@ -12,14 +12,19 @@ public class GamesRepository {
 
   // スコア追加
   public void addScore(
-      final int userId, final int roomId, final int challengeId, final byte scoreType) {
-    gamesMapper.addScore(userId, roomId, challengeId, scoreType);
+      final int userId, final int roomId, final int challengeId, final byte gameId) {
+    gamesMapper.addScore(userId, roomId, challengeId, gameId);
   }
 
   // ゲーム取得
   public Games fetchGame(
-      final int userId, final int roomId, final int challengeId, final byte scoreType) {
-    return gamesMapper.fetchGame(userId, roomId, challengeId, scoreType);
+      final int userId, final int roomId, final int challengeId, final byte gameId) {
+    return gamesMapper.fetchGame(userId, roomId, challengeId, gameId);
+  }
+
+  // 課題ID取得
+  public int[] fetchChallengeIds(final int roomId) {
+    return gamesMapper.fetchChallengeIds(roomId);
   }
 
   // スコア取得

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/repository/cyber_wars/GamesRepository.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/repository/cyber_wars/GamesRepository.java
@@ -10,10 +10,20 @@ import org.springframework.stereotype.Repository;
 public class GamesRepository {
   private final GamesMapper gamesMapper;
 
+  // ゲーム追加
+  public void addGame(
+      final int userId, final int roomId, final int challengeId, final byte gameId) {
+    gamesMapper.addGame(userId, roomId, challengeId, gameId);
+  }
+
   // スコア追加
   public void addScore(
-      final int userId, final int roomId, final int challengeId, final byte gameId) {
-    gamesMapper.addScore(userId, roomId, challengeId, gameId);
+      final int userId,
+      final int challengeId,
+      final int roomId,
+      final byte gameId,
+      final short scoreMultiplier) {
+    gamesMapper.addScore(userId, challengeId, roomId, gameId, scoreMultiplier);
   }
 
   // ゲーム取得

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/repository/cyber_wars/RoomsRepository.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/repository/cyber_wars/RoomsRepository.java
@@ -1,12 +1,13 @@
 package jp.ac.anan.procon.cyber_wars.infrastructure.repository.cyber_wars;
 
-import java.sql.Timestamp;
-import java.util.List;
 import jp.ac.anan.procon.cyber_wars.domain.entity.Rooms;
 import jp.ac.anan.procon.cyber_wars.domain.pojo.TimeLimit;
 import jp.ac.anan.procon.cyber_wars.infrastructure.mapper.cyber_wars.RoomsMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.sql.Timestamp;
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -47,6 +48,11 @@ public class RoomsRepository {
   // 制限時間取得
   public TimeLimit fetchTimeLimit(final int roomId) {
     return roomsMapper.fetchTimeLimit(roomId);
+  }
+
+  // スコア倍率取得
+  public short fetchScoreMultiplier(final int roomId, final String phase, final short timeOffset) {
+    return roomsMapper.fetchScoreMultiplier(roomId, phase, timeOffset);
   }
 
   // ルーム動作判定

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/repository/cyber_wars/RoomsRepository.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/repository/cyber_wars/RoomsRepository.java
@@ -3,6 +3,7 @@ package jp.ac.anan.procon.cyber_wars.infrastructure.repository.cyber_wars;
 import java.sql.Timestamp;
 import java.util.List;
 import jp.ac.anan.procon.cyber_wars.domain.entity.Rooms;
+import jp.ac.anan.procon.cyber_wars.domain.pojo.TimeLimit;
 import jp.ac.anan.procon.cyber_wars.infrastructure.mapper.cyber_wars.RoomsMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -13,8 +14,14 @@ public class RoomsRepository {
   private final RoomsMapper roomsMapper;
 
   // ルーム作成
-  public void create(final short inviteId) {
-    roomsMapper.create(inviteId);
+  public void create(
+      final short inviteId,
+      final int challengeId,
+      final short attackPhaseTimeLimit,
+      final short defencePhaseTimeLimit,
+      final short battlePhaseTimeLimit) {
+    roomsMapper.create(
+        inviteId, challengeId, attackPhaseTimeLimit, defencePhaseTimeLimit, battlePhaseTimeLimit);
   }
 
   // ルーム取得 by 招待ID
@@ -37,19 +44,34 @@ public class RoomsRepository {
     return roomsMapper.fetchStartTime(roomId);
   }
 
+  // 制限時間取得
+  public TimeLimit fetchTimeLimit(final int roomId) {
+    return roomsMapper.fetchTimeLimit(roomId);
+  }
+
   // ルーム動作判定
   public boolean isActive(final int roomId) {
     return roomsMapper.isActive(roomId);
   }
 
   // 課題ID更新
-  public void updateChallengeId(final int roomId) {
-    roomsMapper.updateChallengeId(roomId);
+  public void updateChallengeId(final int roomId, final int challengeId) {
+    roomsMapper.updateChallengeId(roomId, challengeId);
   }
 
   // ゲーム開始時刻更新
   public void updateStartTime(final int roomId) {
     roomsMapper.updateStartTime(roomId);
+  }
+
+  // 制限時間更新
+  public void updateTimeLimit(final int roomId, final TimeLimit timeLimit) {
+    roomsMapper.updateTimeLimit(roomId, timeLimit);
+  }
+
+  // ルーム開放
+  public void open(final int roomId) {
+    roomsMapper.open(roomId);
   }
 
   // ルーム閉鎖

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/repository/cyber_wars/RoomsRepository.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/repository/cyber_wars/RoomsRepository.java
@@ -1,13 +1,12 @@
 package jp.ac.anan.procon.cyber_wars.infrastructure.repository.cyber_wars;
 
+import java.sql.Timestamp;
+import java.util.List;
 import jp.ac.anan.procon.cyber_wars.domain.entity.Rooms;
 import jp.ac.anan.procon.cyber_wars.domain.pojo.TimeLimit;
 import jp.ac.anan.procon.cyber_wars.infrastructure.mapper.cyber_wars.RoomsMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-
-import java.sql.Timestamp;
-import java.util.List;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/repository/cyber_wars/ScoresRepository.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/infrastructure/repository/cyber_wars/ScoresRepository.java
@@ -10,7 +10,7 @@ public class ScoresRepository {
   private final ScoresMapper scoresMapper;
 
   // スコア取得
-  public short fetchScore(final byte scoreType) {
-    return scoresMapper.fetchScore(scoreType);
+  public short fetchScore(final byte gameId) {
+    return scoresMapper.fetchScore(gameId);
   }
 }

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/web/controller/GameAttackController.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/web/controller/GameAttackController.java
@@ -52,7 +52,7 @@ public class GameAttackController {
     return ResponseEntity.ok().build();
   }
 
-  // アタックフェーズ：フラグ送信
+  // アタックフェーズ：キー送信
   @PostMapping("/key")
   @ResponseBody
   public ResponseEntity<?> sendKey(

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/web/controller/GameBattleController.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/web/controller/GameBattleController.java
@@ -38,7 +38,7 @@ public class GameBattleController {
     return ResponseEntity.ok(gameBattleService.fetchRevision(httpServletRequest));
   }
 
-  // バトルフェーズ：フラグ送信
+  // バトルフェーズ：キー送信
   @PostMapping("/key")
   @ResponseBody
   public ResponseEntity<?> sendKey(

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/web/controller/GameController.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/web/controller/GameController.java
@@ -42,7 +42,7 @@ public class GameController {
   // ゲーム開始時刻取得
   @GetMapping("/start-time")
   @ResponseBody
-  public ResponseEntity<?> fetchInformation(
+  public ResponseEntity<?> fetchStartTime(
       @RequestHeader("X-CSRF-Token") String clientCsrfToken,
       final HttpServletRequest httpServletRequest) {
     final HttpClientErrorHandlerResponse httpClientErrorHandlerResponse =
@@ -81,19 +81,19 @@ public class GameController {
     return ResponseEntity.ok(gameService.fetchExplanation(httpServletRequest));
   }
 
-  // 解説取得
+  // ゲーム終了
   @DeleteMapping
+  @ResponseBody
   public ResponseEntity<?> endGame(
       @RequestHeader("X-CSRF-Token") String clientCsrfToken,
       @RequestBody @Validated final EndGameRequest endGameRequest,
       final BindingResult bindingResult,
       final HttpServletRequest httpServletRequest) {
     final HttpClientErrorHandlerResponse httpClientErrorHandlerResponse =
-        httpClientErrorHandler.handle(clientCsrfToken, null, httpServletRequest);
+        httpClientErrorHandler.handle(clientCsrfToken, bindingResult, httpServletRequest);
     if (httpClientErrorHandlerResponse.error()) {
       return httpClientErrorHandlerResponse.responseEntity();
     }
-    gameService.endGame(endGameRequest, httpServletRequest);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.ok(gameService.endGame(endGameRequest, httpServletRequest));
   }
 }

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/web/controller/GameDefenceController.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/web/controller/GameDefenceController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -22,6 +23,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class GameDefenceController {
   private final HttpClientErrorHandler httpClientErrorHandler;
   private final GameDefenceService gameDefenceService;
+
+  // ディフェンスフェーズ：修正課題パス取得
+  @GetMapping("/revision-path")
+  @ResponseBody
+  public ResponseEntity<?> fetchRevisionPath(
+      @RequestHeader("X-CSRF-Token") String clientCsrfToken,
+      final HttpServletRequest httpServletRequest) {
+    final HttpClientErrorHandlerResponse httpClientErrorHandlerResponse =
+        httpClientErrorHandler.handle(clientCsrfToken, null, httpServletRequest);
+    if (httpClientErrorHandlerResponse.error()) {
+      return httpClientErrorHandlerResponse.responseEntity();
+    }
+    return ResponseEntity.ok(gameDefenceService.fetchRevisionPath(httpServletRequest));
+  }
 
   // ディフェンスフェーズ：コード送信
   @PutMapping("/code")

--- a/src/main/java/jp/ac/anan/procon/cyber_wars/web/controller/RoomController.java
+++ b/src/main/java/jp/ac/anan/procon/cyber_wars/web/controller/RoomController.java
@@ -3,7 +3,9 @@ package jp.ac.anan.procon.cyber_wars.web.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import jp.ac.anan.procon.cyber_wars.application.service.RoomService;
 import jp.ac.anan.procon.cyber_wars.application.utility.HttpClientErrorHandler;
+import jp.ac.anan.procon.cyber_wars.domain.dto.room.CreateRequest;
 import jp.ac.anan.procon.cyber_wars.domain.dto.room.JoinRequest;
+import jp.ac.anan.procon.cyber_wars.domain.dto.room.UpdateTimeLimitRequest;
 import jp.ac.anan.procon.cyber_wars.domain.dto.utility.HttpClientErrorHandlerResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +13,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,13 +34,15 @@ public class RoomController {
   @ResponseBody
   public ResponseEntity<?> create(
       @RequestHeader("X-CSRF-Token") String clientCsrfToken,
+      @RequestBody @Validated final CreateRequest createRequest,
+      final BindingResult bindingResult,
       final HttpServletRequest httpServletRequest) {
     final HttpClientErrorHandlerResponse httpClientErrorHandlerResponse =
-        httpClientErrorHandler.handle(clientCsrfToken, null, httpServletRequest);
+        httpClientErrorHandler.handle(clientCsrfToken, bindingResult, httpServletRequest);
     if (httpClientErrorHandlerResponse.error()) {
       return httpClientErrorHandlerResponse.responseEntity();
     }
-    return ResponseEntity.ok(roomService.create(httpServletRequest));
+    return ResponseEntity.ok(roomService.create(createRequest, httpServletRequest));
   }
 
   // ルーム参加
@@ -68,6 +73,22 @@ public class RoomController {
       return httpClientErrorHandlerResponse.responseEntity();
     }
     return ResponseEntity.ok(roomService.fetchInformation(httpServletRequest));
+  }
+
+  // ルーム制限時間更新
+  @PatchMapping
+  public ResponseEntity<?> updateTimeLimit(
+      @RequestHeader("X-CSRF-Token") String clientCsrfToken,
+      @RequestBody @Validated final UpdateTimeLimitRequest updateTimeLimitRequest,
+      final BindingResult bindingResult,
+      final HttpServletRequest httpServletRequest) {
+    final HttpClientErrorHandlerResponse httpClientErrorHandlerResponse =
+        httpClientErrorHandler.handle(clientCsrfToken, bindingResult, httpServletRequest);
+    if (httpClientErrorHandlerResponse.error()) {
+      return httpClientErrorHandlerResponse.responseEntity();
+    }
+    roomService.updateTimeLimit(updateTimeLimitRequest, httpServletRequest);
+    return ResponseEntity.ok().build();
   }
 
   // ルーム退出


### PR DESCRIPTION
## Issueへのリンク
<!-- resolve: #Issue番号 -->
resolve: #269 

## 概要
あらゆるバグの修正

## 作業内容
- 再戦機能（gamesにscoretype追加フラグ）
- fetchRevisionの中でactiveを
- ディフェンスの左の画面は自分のが出るようにAPI追加（opponentRevisionPathとrevisionPath）
- 点数に時間を加算
- table名の書き換えを一番最初にしないと何もディフェンスフェーズで変えなかった時にそのまま
- 制限時間設定API追加、FetchInfo更新
- roomsにそれぞれのフェーズの制限時間カラムを追加
- score_typeをgame_idに
- game_idにスキップフラグ作成
- scoresのgame_id更新

## 動作確認
<!-- 必要であれば実施して記載 -->
なし

## レビュワーへの参考情報
<!-- 実装上の懸念点やレビューにおける注意点などがもしあれば記載 -->
なし
